### PR TITLE
fix infernence output for filename without dir

### DIFF
--- a/tools/diffusion/inference.py
+++ b/tools/diffusion/inference.py
@@ -391,8 +391,8 @@ class SVCInference(nn.Module):
         logger.info("Done")
 
         if output_path is not None:
-            if os.path.exists(os.path.dirname(output_path)) is False:
-                os.makedirs(os.path.dirname(output_path))
+            if len(os.path.dirname(output_path)) > 0:
+                os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
             sf.write(output_path, generated_audio, sr)
 


### PR DESCRIPTION
fix the problem when this output filename without dirname

Bug
```shell
$ python tools/hifisinger/inference.py --config <config>--checkpoint <ckpt> --input input.wav --output out.wav

2023-06-22 21:16:38.077 | INFO     | tools.diffusion.inference:inference:312 - Loaded input.wav with sr=44100
2023-06-22 21:16:38.210 | INFO     | tools.diffusion.inference:inference:356 - Sliced into 5 segments
2023-06-22 21:16:38.214 | INFO     | tools.diffusion.inference:inference:366 - Processing segment 1/5, duration: 21.83s
2023-06-22 21:16:43.205 | INFO     | tools.diffusion.inference:inference:366 - Processing segment 2/5, duration: 20.96s
2023-06-22 21:16:46.854 | INFO     | tools.diffusion.inference:inference:366 - Processing segment 3/5, duration: 20.96s
2023-06-22 21:16:50.496 | INFO     | tools.diffusion.inference:inference:366 - Processing segment 4/5, duration: 20.60s
2023-06-22 21:16:54.155 | INFO     | tools.diffusion.inference:inference:366 - Processing segment 5/5, duration: 20.82s
2023-06-22 21:16:57.804 | INFO     | tools.diffusion.inference:inference:391 - Done
Traceback (most recent call last):
  File "/xxx/fish-diffusion/tools/hifisinger/inference.py", line 227, in <module>
    model.inference(
  File "/home/yyy/.conda/envs/fish/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/yyy/Repos/fish-diffusion/tools/diffusion/inference.py", line 395, in inference
    os.makedirs(os.path.dirname(output_path))
  File "/home/yyy/.conda/envs/fish/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''
```